### PR TITLE
Need the 'venue' attribute for rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: bootcamp2
 root: .
+venue: MSU BEACON
 venue1: MSU BEACON
 address1: 567 Wilson Road, BPS Room 1441, East Lansing, MI
 venue2: UT Austin BEACON (via teleconference)


### PR DESCRIPTION
Have to have a `venue` tag in the YAML header for proper rendering on the SWC website.
